### PR TITLE
Add Firebase push notifications

### DIFF
--- a/CentralPushNotifications/CentralPushNotifications.csproj
+++ b/CentralPushNotifications/CentralPushNotifications.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.63.0" />
   </ItemGroup>
 
 </Project>

--- a/CentralPushNotifications/Controllers/NotificationsController.cs
+++ b/CentralPushNotifications/Controllers/NotificationsController.cs
@@ -1,0 +1,29 @@
+using CentralPushNotifications.Models;
+using CentralPushNotifications.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CentralPushNotifications.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class NotificationsController : ControllerBase
+{
+    private readonly FcmService _fcmService;
+
+    public NotificationsController(FcmService fcmService)
+    {
+        _fcmService = fcmService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Send(NotificationRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Token))
+        {
+            return BadRequest("Token is required");
+        }
+
+        var id = await _fcmService.SendAsync(request.Title, request.Body, request.Token);
+        return Ok(new { id });
+    }
+}

--- a/CentralPushNotifications/Models/NotificationRequest.cs
+++ b/CentralPushNotifications/Models/NotificationRequest.cs
@@ -1,0 +1,8 @@
+namespace CentralPushNotifications.Models;
+
+public class NotificationRequest
+{
+    public string Token { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+}

--- a/CentralPushNotifications/Program.cs
+++ b/CentralPushNotifications/Program.cs
@@ -1,3 +1,5 @@
+using CentralPushNotifications.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -6,6 +8,7 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<FcmService>();
 
 var app = builder.Build();
 

--- a/CentralPushNotifications/Services/FcmService.cs
+++ b/CentralPushNotifications/Services/FcmService.cs
@@ -1,0 +1,41 @@
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
+using Google.Apis.Auth.OAuth2;
+
+namespace CentralPushNotifications.Services;
+
+public class FcmService
+{
+    private readonly FirebaseApp _app;
+
+    public FcmService(IConfiguration configuration)
+    {
+        var path = configuration["Firebase:CredentialsPath"];
+        if (FirebaseApp.DefaultInstance == null)
+        {
+            _app = FirebaseApp.Create(new AppOptions
+            {
+                Credential = GoogleCredential.FromFile(path)
+            });
+        }
+        else
+        {
+            _app = FirebaseApp.DefaultInstance;
+        }
+    }
+
+    public async Task<string> SendAsync(string title, string body, string token)
+    {
+        var message = new Message
+        {
+            Notification = new Notification
+            {
+                Title = title,
+                Body = body
+            },
+            Token = token
+        };
+
+        return await FirebaseMessaging.DefaultInstance.SendAsync(message);
+    }
+}

--- a/CentralPushNotifications/appsettings.Development.json
+++ b/CentralPushNotifications/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Firebase": {
+    "CredentialsPath": "path/to/credentials.json"
   }
 }

--- a/CentralPushNotifications/appsettings.json
+++ b/CentralPushNotifications/appsettings.json
@@ -6,4 +6,7 @@
     }
   },
   "AllowedHosts": "*"
+  ,"Firebase": {
+    "CredentialsPath": "path/to/credentials.json"
+  }
 }


### PR DESCRIPTION
## Summary
- add FCM service and notification controller
- wire up the service in Program.cs
- configure Firebase credentials path in appsettings
- add FirebaseAdmin packages

## Testing
- `dotnet build CentralPushNotifications.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf748cdc8320ab661a6f7793f66d