### PR TITLE
Add firebase config template and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# Firebase credentials
+Firebase/*.json
+!Firebase/serviceAccount.example.json
+!Firebase/firebase.client.example.json

--- a/CentralPushNotifications/appsettings.Development.json
+++ b/CentralPushNotifications/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "Firebase": {
-    "CredentialsPath": "path/to/credentials.json"
+    "CredentialsPath": "Firebase/serviceAccount.json"
   }
 }

--- a/CentralPushNotifications/appsettings.json
+++ b/CentralPushNotifications/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*"
   ,"Firebase": {
-    "CredentialsPath": "path/to/credentials.json"
+    "CredentialsPath": "Firebase/serviceAccount.json"
   }
 }

--- a/Firebase/firebase.client.example.json
+++ b/Firebase/firebase.client.example.json
@@ -1,0 +1,8 @@
+{
+  "apiKey": "YOUR_API_KEY",
+  "authDomain": "your-app.firebaseapp.com",
+  "projectId": "your-app",
+  "storageBucket": "your-app.appspot.com",
+  "messagingSenderId": "YOUR_MESSAGING_SENDER_ID",
+  "appId": "YOUR_APP_ID"
+}

--- a/Firebase/serviceAccount.example.json
+++ b/Firebase/serviceAccount.example.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  "private_key_id": "your-private-key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk@example.iam.gserviceaccount.com",
+  "client_id": "your-client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk@example.iam.gserviceaccount.com"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# CentralPushNotifications
+
+This project provides a minimal ASP.NET Core API for sending Firebase Cloud Messaging (FCM) push notifications.
+
+## Firebase configuration
+
+1. Create a Firebase project in the [Firebase console](https://console.firebase.google.com/).
+2. Generate a new **service account** key and download the JSON credentials file.
+3. Place the downloaded file somewhere on your server and set its path in `appsettings.Development.json` (or `appsettings.json`) under the `Firebase:CredentialsPath` option.
+4. Copy `Firebase/serviceAccount.example.json` to the location of your credentials file and fill it with your real values.
+
+Front-end applications can share the configuration found in `Firebase/firebase.client.example.json`.
+
+## Running the API
+
+```bash
+# Build the solution
+# dotnet build
+
+# Run the API
+# dotnet run --project CentralPushNotifications/CentralPushNotifications.csproj
+```
+
+The API exposes a single endpoint `/notifications` to send a push notification using a device token.


### PR DESCRIPTION
## Summary
- add basic firebase configuration examples
- document firebase setup and how to run the API
- ignore real firebase credential files
- set default credential path in appsettings

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434d892ddc83209ad3162fe3dda162