### PR TITLE
Add basic user management with JWT auth

### DIFF
--- a/CentralPushNotifications/CentralPushNotifications.csproj
+++ b/CentralPushNotifications/CentralPushNotifications.csproj
@@ -10,6 +10,9 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
     <PackageReference Include="FirebaseAdmin" Version="3.2.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/CentralPushNotifications/Controllers/UsersController.cs
+++ b/CentralPushNotifications/Controllers/UsersController.cs
@@ -1,0 +1,106 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using CentralPushNotifications.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+
+namespace CentralPushNotifications.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly UserManager<IdentityUser> _userManager;
+    private readonly IConfiguration _configuration;
+
+    public UsersController(UserManager<IdentityUser> userManager, IConfiguration configuration)
+    {
+        _userManager = userManager;
+        _configuration = configuration;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterRequest request)
+    {
+        var user = new IdentityUser { UserName = request.UserName, Email = request.Email };
+        var result = await _userManager.CreateAsync(user, request.Password);
+        if (!result.Succeeded)
+        {
+            return BadRequest(result.Errors);
+        }
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginRequest request)
+    {
+        var user = await _userManager.FindByNameAsync(request.UserName);
+        if (user == null || !await _userManager.CheckPasswordAsync(user, request.Password))
+        {
+            return Unauthorized();
+        }
+
+        var token = GenerateJwtToken(user);
+        return Ok(new { token });
+    }
+
+    [Authorize]
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(string id, UpdateUserRequest request)
+    {
+        var user = await _userManager.FindByIdAsync(id);
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.UserName))
+        {
+            user.UserName = request.UserName;
+        }
+        if (!string.IsNullOrWhiteSpace(request.Email))
+        {
+            user.Email = request.Email;
+        }
+        var result = await _userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+        {
+            return BadRequest(result.Errors);
+        }
+        return NoContent();
+    }
+
+    [Authorize]
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var user = await _userManager.FindByIdAsync(id);
+        if (user == null)
+        {
+            return NotFound();
+        }
+        await _userManager.DeleteAsync(user);
+        return NoContent();
+    }
+
+    private string GenerateJwtToken(IdentityUser user)
+    {
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, user.UserName!),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/CentralPushNotifications/Data/ApplicationDbContext.cs
+++ b/CentralPushNotifications/Data/ApplicationDbContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace CentralPushNotifications.Data;
+
+public class ApplicationDbContext : IdentityDbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/CentralPushNotifications/Models/LoginRequest.cs
+++ b/CentralPushNotifications/Models/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace CentralPushNotifications.Models;
+
+public class LoginRequest
+{
+    public string UserName { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/CentralPushNotifications/Models/RegisterRequest.cs
+++ b/CentralPushNotifications/Models/RegisterRequest.cs
@@ -1,0 +1,8 @@
+namespace CentralPushNotifications.Models;
+
+public class RegisterRequest
+{
+    public string UserName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/CentralPushNotifications/Models/UpdateUserRequest.cs
+++ b/CentralPushNotifications/Models/UpdateUserRequest.cs
@@ -1,0 +1,7 @@
+namespace CentralPushNotifications.Models;
+
+public class UpdateUserRequest
+{
+    public string? UserName { get; set; }
+    public string? Email { get; set; }
+}

--- a/CentralPushNotifications/Program.cs
+++ b/CentralPushNotifications/Program.cs
@@ -1,4 +1,10 @@
 using CentralPushNotifications.Services;
+using CentralPushNotifications.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,6 +15,29 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<FcmService>();
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseInMemoryDatabase("DefaultDb"));
+builder.Services.AddIdentity<IdentityUser, IdentityRole>()
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddDefaultTokenProviders();
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+    };
+});
+builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
@@ -21,6 +50,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/CentralPushNotifications/appsettings.Development.json
+++ b/CentralPushNotifications/appsettings.Development.json
@@ -7,5 +7,10 @@
   },
   "Firebase": {
     "CredentialsPath": "Firebase/serviceAccount.json"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKey12345",
+    "Issuer": "CentralPushNotifications",
+    "Audience": "CentralPushNotifications"
   }
 }

--- a/CentralPushNotifications/appsettings.json
+++ b/CentralPushNotifications/appsettings.json
@@ -5,8 +5,13 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  ,"Firebase": {
+  "AllowedHosts": "*",
+  "Firebase": {
     "CredentialsPath": "Firebase/serviceAccount.json"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKey12345",
+    "Issuer": "CentralPushNotifications",
+    "Audience": "CentralPushNotifications"
   }
 }


### PR DESCRIPTION
## Summary
- add Identity with EF Core in-memory store
- secure endpoints with JWT authentication
- configure JWT options
- implement user CRUD endpoints

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6ac9e948320acc0d524de1bc332